### PR TITLE
Created a fix for sockets app hang

### DIFF
--- a/XCode/Sources/HttpRequest.swift
+++ b/XCode/Sources/HttpRequest.swift
@@ -16,6 +16,7 @@ public class HttpRequest {
     public var body: [UInt8] = []
     public var address: String? = ""
     public var params: [String: String] = [:]
+    public var remotePort: UInt16 = 0
 
     public init() {}
 

--- a/XCode/Sources/HttpServerIO.swift
+++ b/XCode/Sources/HttpServerIO.swift
@@ -120,6 +120,7 @@ open class HttpServerIO {
         while self.operating, let request = try? parser.readHttpRequest(socket) {
             let request = request
             request.address = try? socket.peername()
+            request.remotePort = (try? socket.peerport()) ?? 0
             let (params, handler) = self.dispatch(request)
             request.params = params
             let response = handler(request)

--- a/XCode/Sources/Socket.swift
+++ b/XCode/Sources/Socket.swift
@@ -215,12 +215,16 @@ open class Socket: Hashable, Equatable {
         return String(cString: hostBuffer)
     }
     
+    /// This method returns  the port of the remote socket that this socket is connected to
+    /// In fact, getpeername API returns the address of the remote party of a connection
+    /// but getpeername only reads the IP address off that leaving out the port,
+    /// hence the need for this method
     public func peerport() throws -> in_port_t {
         var addr = sockaddr_in()
         return try withUnsafePointer(to: &addr) { pointer in
             var len = socklen_t(MemoryLayout<sockaddr_in>.size)
             if getpeername(self.socketFileDescriptor, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
-                throw SocketError.getSockNameFailed(Errno.description())
+                throw SocketError.getPeerNameFailed(Errno.description())
             }
             let sin_port = pointer.pointee.sin_port
         #if os(Linux)

--- a/Xcode/Sources/HttpServerIO.swift
+++ b/Xcode/Sources/HttpServerIO.swift
@@ -75,25 +75,26 @@ open class HttpServerIO {
         let address = forceIPv4 ? listenAddressIPv4 : listenAddressIPv6
         self.socket = try Socket.tcpSocketForListen(port, forceIPv4, SOMAXCONN, address)
         self.state = .running
+        
         DispatchQueue.global(qos: priority).async { [weak self] in
             guard let strongSelf = self else { return }
             guard strongSelf.operating else { return }
-            while let socket = try? strongSelf.socket.acceptClientSocket() {
+            while let socket = try? self?.socket.acceptClientSocket() {
                 DispatchQueue.global(qos: priority).async { [weak self] in
                     guard let strongSelf = self else { return }
                     guard strongSelf.operating else { return }
-                    strongSelf.queue.async {
-                        strongSelf.sockets.insert(socket)
+                    self?.queue.async {
+                        self?.sockets.insert(socket)
                     }
 
-                    strongSelf.handleConnection(socket)
+                    self?.handleConnection(socket)
 
-                    strongSelf.queue.async {
-                        strongSelf.sockets.remove(socket)
+                    self?.queue.async {
+                        self?.sockets.remove(socket)
                     }
                 }
             }
-            strongSelf.stop()
+            self?.stop()
         }
     }
 


### PR DESCRIPTION
I think keeping the reference in the let constant, from the guard statements, of self and using it may cause the issue because self may not be deallocated. In this case it is much better to used “self?”. This way we know for sure that the code it is not running because self is no more.
